### PR TITLE
Fix robotiq_85_gripper driver launch crash

### DIFF
--- a/robotiq_85_driver/setup.py
+++ b/robotiq_85_driver/setup.py
@@ -3,11 +3,12 @@ from glob import glob
 from setuptools import setup
 
 package_name = 'robotiq_85_driver'
+package_subdirectory = 'robotiq_85_driver/driver'
 
 setup(
     name=package_name,
     version='1.0.0',
-    packages=[package_name],
+    packages=[package_name, package_subdirectory],
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),


### PR DESCRIPTION
The subdirectory `robotiq_85_gripper/robotiq_85_gripper/driver` was not being installed, causing `gripper_driver.launch.py` to fail. Added this path to be installed via `setup.py`