### PR TITLE
Fix noisy output from gripper driver.

### DIFF
--- a/robotiq_85_driver/robotiq_85_driver/robotiq_85_driver.py
+++ b/robotiq_85_driver/robotiq_85_driver/robotiq_85_driver.py
@@ -64,9 +64,6 @@ class Robotiq85Driver(Node):
     def __init__(self):
         super().__init__('robotiq_85_driver')
 
-        # put a leep so it can connect to the force/torque sensor first
-        time.sleep(5.0)
-
         self.declare_parameter('num_grippers', 1)
         self.declare_parameter('comport', '/dev/ttyUSB0')
         self.declare_parameter('baud', '115200')


### PR DESCRIPTION
This PR addresses the noisy output from the gripper driver.  The sleep statement in the `Robotiq85Driver` constructor caused the driver to take a long time to start up, and the warnings were generated by other nodes waiting on its output.