### PR TITLE
Add ros2_control xacro

### DIFF
--- a/robotiq_85_description/urdf/robotiq_85_gripper.ros2_control.xacro
+++ b/robotiq_85_description/urdf/robotiq_85_gripper.ros2_control.xacro
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <xacro:macro name="robotiq_85_gripper_ros2_control" params="name">
+        <ros2_control name="${name}" type="system">
+            <hardware>
+                <plugin>fake_components/GenericSystem</plugin>
+            </hardware>
+            <joint name="robotiq_85_left_knuckle_joint">
+                <param name="initial_position">0.7929</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="robotiq_85_right_knuckle_joint">
+                <param name="mimic">robotiq_85_left_knuckle_joint</param>
+                <param name="multiplier">1</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+
+            <joint name="robotiq_85_left_inner_knuckle_joint">
+                <param name="mimic">robotiq_85_left_knuckle_joint</param>
+                <param name="multiplier">1</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="robotiq_85_right_inner_knuckle_joint">
+                <param name="mimic">robotiq_85_left_knuckle_joint</param>
+                <param name="multiplier">1</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+
+            <joint name="robotiq_85_left_finger_tip_joint">
+                <param name="mimic">robotiq_85_left_knuckle_joint</param>
+                <param name="multiplier">-1</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="robotiq_85_right_finger_tip_joint">
+                <param name="mimic">robotiq_85_left_knuckle_joint</param>
+                <param name="multiplier">-1</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+        </ros2_control>
+    </xacro:macro>
+
+</robot>

--- a/robotiq_85_description/urdf/robotiq_85_gripper_macro.urdf.xacro
+++ b/robotiq_85_description/urdf/robotiq_85_gripper_macro.urdf.xacro
@@ -22,6 +22,11 @@
 	</xacro:macro>
 
 	<xacro:macro name="robotiq_85_gripper" params="prefix parent *origin">
+		
+		<!-- ros2 control include -->
+		<xacro:include filename="$(find robotiq_85_description)/urdf/robotiq_85_gripper.ros2_control.xacro"/>
+		<!-- ros2 control instance -->
+		<xacro:robotiq_85_gripper_ros2_control name="RobotiqGripperSystem"/>
 
 		<joint name="${prefix}robotiq_85_base_joint" type="fixed">
 			<parent link="${parent}"/>


### PR DESCRIPTION
This adds the ros2_control xacro needed to simulate the gripper and calls the macro in the main URDF. Long term it is also required when we upgrade the driver to work as a hardware_interface in ros2_control.