### PR TITLE
Make ros_control optional

### DIFF
--- a/robotiq_85_description/urdf/robotiq_85_gripper_macro.urdf.xacro
+++ b/robotiq_85_description/urdf/robotiq_85_gripper_macro.urdf.xacro
@@ -21,12 +21,14 @@
 		</gazebo>
 	</xacro:macro>
 
-	<xacro:macro name="robotiq_85_gripper" params="prefix parent *origin">
+	<xacro:macro name="robotiq_85_gripper" params="prefix parent *origin sim:=false">
 		
-		<!-- ros2 control include -->
-		<xacro:include filename="$(find robotiq_85_description)/urdf/robotiq_85_gripper.ros2_control.xacro"/>
-		<!-- ros2 control instance -->
-		<xacro:robotiq_85_gripper_ros2_control name="RobotiqGripperSystem"/>
+		<xacro:if value="${sim}">
+			<!-- ros2 control include -->
+			<xacro:include filename="$(find robotiq_85_description)/urdf/robotiq_85_gripper.ros2_control.xacro"/>
+			<!-- ros2 control instance -->
+			<xacro:robotiq_85_gripper_ros2_control name="RobotiqGripperSystem"/>
+		</xacro:if>
 
 		<joint name="${prefix}robotiq_85_base_joint" type="fixed">
 			<parent link="${parent}"/>

--- a/robotiq_85_description/urdf/robotiq_85_gripper_macro.urdf.xacro
+++ b/robotiq_85_description/urdf/robotiq_85_gripper_macro.urdf.xacro
@@ -23,6 +23,10 @@
 
 	<xacro:macro name="robotiq_85_gripper" params="prefix parent *origin sim:=false">
 		
+		<!-- The current hardware driver does not depend on ros2_control but we do utilize
+				 it for simulating the gripper in Gazebo. Enabling this on hardware causes the
+				 JointStateBroadcaster to publish values for all joints including ones that are
+				 mimic'd which is causing issues on systems consuming the joint_state data. -->
 		<xacro:if value="${sim}">
 			<!-- ros2 control include -->
 			<xacro:include filename="$(find robotiq_85_description)/urdf/robotiq_85_gripper.ros2_control.xacro"/>


### PR DESCRIPTION
This adds an argument to the URDF that only includes ros_control when simulating the gripper.